### PR TITLE
Skip Reporting Temporary Failures due to Acceptable Exceptions

### DIFF
--- a/lib/honeybadger/plugins/delayed_job/plugin.rb
+++ b/lib/honeybadger/plugins/delayed_job/plugin.rb
@@ -4,6 +4,10 @@ require 'honeybadger/ruby'
 module Honeybadger
   module Plugins
     module DelayedJob
+      ACCEPTABLE_EXCEPTIONS = [
+        'Intuit::Error::InternalServerError',
+        'Square::Error::InternalServerError',
+      ]
       class Plugin < ::Delayed::Plugin
         callbacks do |lifecycle|
           lifecycle.around(:invoke_job) do |job, &block|
@@ -44,14 +48,18 @@ module Honeybadger
 
               block.call(job)
             rescue Exception => error
-              DelayedJobBadger.notify(
-                :component     => component,
-                :action        => action,
-                :error_class   => error.class.name,
-                :error_message => "#{ error.class.name }: #{ error.message }",
-                :backtrace     => error.backtrace,
-                :exception     => error
-              ) if job.attempts.to_i >= DelayedJobBadger.config[:'delayed_job.attempt_threshold'].to_i
+              # Skip reporting temporarily failed jobs that have an acceptable exception
+              if job.attempts.to_i >= DelayedJobBadger.config[:'delayed_job.attempt_threshold'].to_i &&
+                (job.failed_at.present? || ACCEPTABLE_EXCEPTIONS.exclude?(error.class.name))
+                DelayedJobBadger.notify(
+                  :component     => component,
+                  :action        => action,
+                  :error_class   => error.class.name,
+                  :error_message => "#{ error.class.name }: #{ error.message }",
+                  :backtrace     => error.backtrace,
+                  :exception     => error
+                )
+              end
               raise error
             ensure
               DelayedJobBadger.context.clear!


### PR DESCRIPTION
Summary: Add a constant that contains acceptable exceptions that we expect to happen during runtime, and expect the retry algorithm to handle.

Add logic to ignore reporting acceptable exceptions, unless the job has permanently failed, as indicated by the presence of `failed_at`

Test Plan: None

JIRA Link: https://simplyinsured.atlassian.net/browse/SI-7378
